### PR TITLE
Re-add missing commits to GOVERNANCE.md/MAINTAINERS

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -49,15 +49,19 @@ maintainer candidates are selected and proposed on the maintainers mailing list.
 
 After a candidate has been announced on the maintainers mailing list, the
 existing maintainers are given five business days to discuss the candidate,
-raise objections and cast their vote. Candidates must be approved by at least
-66% of the current maintainers by adding their vote on the mailing
-list. Only maintainers of the repository that the candidate is proposed for are
-allowed to vote.
+raise objections and cast their vote. Votes may take place on the mailing list
+or via pull request comment. Candidates must be approved by at least 66% of the
+current maintainers by adding their vote on the mailing list. The reviewer role
+has the same process but only requires 33% of current maintainers. Only
+maintainers of the repository that the candidate is proposed for are allowed to
+vote.
 
 If a candidate is approved, a maintainer will contact the candidate to invite
 the candidate to open a pull request that adds the contributor to the
-MAINTAINERS file. The candidate becomes a maintainer once the pull request is
-merged.
+MAINTAINERS file. The voting process may take place inside a pull request if a
+maintainer has already discussed the candidacy with the candidate and a
+maintainer is willing to be a sponsor by opening the pull request. The candidate
+becomes a maintainer once the pull request is merged.
 
 ## Adding sub-projects
 

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -25,3 +25,4 @@
 "jessvalarezo","Jessica Valarezo","valarezo.jessica@gmail.com"
 "yanxuean","Xuean Yan","yan.xuean@zte.com.cn"
 "miaoyq","Yanqiang Miao","miao.yanqiang@zte.com.cn"
+"ehazlett","Evan Hazlett","ejhazlett@gmail.com"


### PR DESCRIPTION
From the containerd/containerd repo, 2 commits occurred since the copyover
to containerd/project happened. This commit adds back
[a4e4af195986e33a399b4b0dcfb6ffaf2954c4d4](https://github.com/containerd/containerd/commit/a4e4af195986e33a399b4b0dcfb6ffaf2954c4d4) and
[7ba62b147daafbb3f56359def179af1794896e79](https://github.com/containerd/containerd/commit/7ba62b147daafbb3f56359def179af1794896e79).

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>