### PR TITLE
Add DCO check, vendor, and test build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.dll
 *.so
 *.dylib
+release-tool
 
 # Test binary, build with `go test -c`
 *.test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: go
+sudo: required
+
+go:
+  - 1.11.x
+
+go_import_path: github.com/containerd/project
+
+install:
+  - go get -u github.com/vbatts/git-validation
+  - go get -u github.com/kunalkushwaha/ltag
+  - go get -u github.com/LK4D4/vndr
+
+script:
+  - DCO_VERBOSITY=-q script/validate/dco
+  - script/validate/fileheader
+  - test -z $(git diff --name-only HEAD~1 | grep vendor) || script/validate/vendor
+  - test -z $(git diff --name-only HEAD~1 | grep -E 'cmd/release-tool|vendor') || go build -o release-tool github.com/containerd/project/cmd/release-tool


### PR DESCRIPTION
Only runs vendor and build checks if related files have changed.

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>