### PR TITLE
Add Wei Fu as maintainer

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -17,6 +17,7 @@
 "Random-Liu","Lantao Liu","lantaol@google.com"
 "mikebrow","Mike Brown","brownwm@us.ibm.com"
 "yujuhong","Yu-Ju Hong","yjhong@google.com"
+"fuweid","Wei Fu","yuge.fw@alibaba-inc.com"
 #
 # REVIEWERS
 # GitHub ID, Name, Email address
@@ -25,5 +26,4 @@
 "yanxuean","Xuean Yan","yan.xuean@zte.com.cn"
 "miaoyq","Yanqiang Miao","miao.yanqiang@zte.com.cn"
 "ehazlett","Evan Hazlett","ejhazlett@gmail.com"
-"fuweid","Wei Fu","yuge.fw@alibaba-inc.com"
 "Ace-Tang","Ace Tang","huamin.thm@alibaba-inc.com"


### PR DESCRIPTION
Wei Fu, better known as @fuweid, has been a committed and valuable contributor and reviewer on containerd for a long time now. He has shown he understand the mission of containerd and cares deeply about preserving containerd's high quality and clean design.

- [x] @AkihiroSuda
- [x] @crosbymichael
- [x] @dmcgowan
- [x] @estesp
- [x] @jhowardmsft
- [x] @jterry75
- [x] @mlaventure
- [ ] @stevvooe
- [x] @abhi
- [x] @dchen1107
- [x] @Random-Liu
- [x] @mikebrow
- [ ] @yujuhong