### PR TITLE
Support Go Modules

### DIFF
--- a/script/validate/vendor
+++ b/script/validate/vendor
@@ -18,7 +18,13 @@
 set -eu -o pipefail
 
 rm -rf vendor/
-vndr |& grep -v -i clone
+
+if [ -f vendor.conf ]; then
+  vndr |& grep -v -i clone
+else
+  go mod tidy
+  go mod vendor
+fi
 
 DIFF_PATH="vendor/"
 DIFF=$(git status --porcelain -- "$DIFF_PATH")


### PR DESCRIPTION
Attempting to support modules for containerd projects. Specifically this PR adds a `go.mod` file for this repo and updates the vendor validation script to support go modules alongside `vndr` by checking for the presence of `vendor.conf` and using `vndr` if it exists or `go mod vendor` if it does not.