### PR TITLE
Use "go mod" instead of vndr when GO111MODULE is "on"

### DIFF
--- a/script/validate/vendor
+++ b/script/validate/vendor
@@ -18,7 +18,14 @@
 set -eu -o pipefail
 
 rm -rf vendor/
-vndr |& grep -v -i clone
+
+if [ "${GO111MODULE:-}" == 'on' ]; then
+    go mod init
+    go mod tidy
+    go mod vendor
+else
+    vndr |& grep -v -i clone
+fi
 
 DIFF_PATH="vendor/"
 DIFF=$(git status --porcelain -- "$DIFF_PATH")


### PR DESCRIPTION
As Derek suggested at
https://github.com/containerd/containerd/pull/3182,
this change adds Go modules support for the script first.

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>