### PR TITLE
Support validating go.{mod,sum} files

### DIFF
--- a/script/validate/vendor
+++ b/script/validate/vendor
@@ -17,16 +17,18 @@
 
 set -eu -o pipefail
 
-rm -rf vendor/
-
 if [ -f vendor.conf ]; then
+  rm -rf vendor/
   vndr |& grep -v -i clone
 else
   go mod tidy
-  go mod vendor
+  if [ -f vendor ]; then
+    rm -rf vendor/
+    go mod vendor
+  fi
 fi
 
-DIFF_PATH="vendor/"
+DIFF_PATH="vendor/ go.mod go.sum"
 DIFF=$(git status --porcelain -- "$DIFF_PATH")
 
 if [ "$DIFF" ]; then


### PR DESCRIPTION
@dmcgowan I think something like this may also be useful, is it what you were talking about the other day? If the vendor tree doesn't exist we don't create it, instead we juts run `go mod tidy` and validate that the `go.sum` and `go.mod` files don't change (if they do the user needs to commit them).