### PR TITLE
Farewell John Howard

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -8,7 +8,6 @@
 "crosbymichael","Michael Crosby","crosbymichael@gmail.com"
 "dmcgowan","Derek McGowan","derek@mcgstyle.net"
 "estesp","Phil Estes","estesp@gmail.com"
-"jhowardmsft","John Howard","jhoward@microsoft.com"
 "jterry75","Justin Terry","juterry@microsoft.com"
 "mlaventure","Kenfe-Mickaël Laventure","mickael.laventure@gmail.com"
 "stevvooe","Stephen Day","stevvooe@gmail.com"


### PR DESCRIPTION
I wanted to take this opportunity to show our appreciation to John Howard for all the work he has done not only on containerd, but pushing forward containers on Windows for many years. Github seems the most appropriate place to express that gratitude. On behalf of the maintainers, thank you John and best of luck!

For fun I found John's first Docker proposal and PR for Windows support in early 2015.
[docker#10662: Proposal: Refactoring to compile Docker Daemon on Windows](https://github.com/moby/moby/issues/10662)
[docker#10971: api\server: Factored out UnixHttp on Windows, supported on Linux only](https://github.com/moby/moby/pull/10971)