### PR TITLE
Move Abhi to reviewers

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -11,7 +11,6 @@
 "jterry75","Justin Terry","juterry@microsoft.com"
 "mlaventure","Kenfe-Mickaël Laventure","mickael.laventure@gmail.com"
 "stevvooe","Stephen Day","stevvooe@gmail.com"
-"abhi","Abhinandan Prativadi","aprativadi@gmail.com"
 "dchen1107","Dawn Chen","dawnchen@google.com"
 "Random-Liu","Lantao Liu","lantaol@google.com"
 "mikebrow","Mike Brown","brownwm@us.ibm.com"
@@ -20,6 +19,7 @@
 #
 # REVIEWERS
 # GitHub ID, Name, Email address
+"abhi","Abhinandan Prativadi","aprativadi@gmail.com"
 "dqminh","Daniel, Dao Quang Minh","dqminh89@gmail.com"
 "hqhq","Qiang Huang","h.huangqiang@huawei.com"
 "yanxuean","Xuean Yan","yan.xuean@zte.com.cn"


### PR DESCRIPTION
Abhi has moved on to work on other projects. Add him as a reviewer to recognize his insight and knowledge of the code without the added responsibility of voting on maintainer issues.