### PR TITLE
script/validate/vendor: remove the double quotes

### DIFF
--- a/script/validate/vendor
+++ b/script/validate/vendor
@@ -29,7 +29,11 @@ else
 fi
 
 DIFF_PATH="vendor/ go.mod go.sum"
-DIFF=$(git status --porcelain -- "$DIFF_PATH")
+
+# need word splitting here to avoid reading the whole DIFF_PATH as one pathspec
+#
+# shellcheck disable=SC2046
+DIFF=$(git status --porcelain -- $DIFF_PATH)
 
 if [ "$DIFF" ]; then
     echo


### PR DESCRIPTION
git-status will take "vendor/ go.mod go.sum" as one path. we should
remove the double quotes.

Signed-off-by: Wei Fu <fuweid89@gmail.com>