### PR TITLE
Don't force project headers on contrib/

### DIFF
--- a/script/validate/fileheader
+++ b/script/validate/fileheader
@@ -25,4 +25,4 @@ fi
 
 BASEPATH="${1-}"
 
-ltag -t "${BASEPATH}script/validate/template" --check -v
+ltag -t "${BASEPATH}script/validate/template" --excludes "vendor contrib" --check -v


### PR DESCRIPTION
Contributed files might include files from other projects with their own
headers/copyrights. We don't want to enforce adding our copyright to
other files

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>