### PR TITLE
Allow setting the commit range for the DCO check

### DIFF
--- a/script/validate/dco
+++ b/script/validate/dco
@@ -24,4 +24,9 @@ if ! command -v git-validation; then
 fi
 
 verbosity="${DCO_VERBOSITY--v}"
-GIT_CHECK_EXCLUDE="./vendor:./script/validate/template" git-validation "$verbosity" -run DCO,short-subject,dangling-whitespace
+range=
+commit_range="${DCO_RANGE-}"
+[ ! -z "${commit_range}" ] && {
+	range="-range ${commit_range}"
+}
+GIT_CHECK_EXCLUDE="./vendor:./script/validate/template" git-validation ${verbosity} ${range} -run DCO,short-subject,dangling-whitespace


### PR DESCRIPTION
To prepare for using non-Travis CI systems, like GitHub actions we need
to be able to pass a commit range to git-validation.

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>