### PR TITLE
Add Justin Cormack as security advisor

### DIFF
--- a/SECURITY_ADVISORS
+++ b/SECURITY_ADVISORS
@@ -4,3 +4,4 @@
 #
 # SECURITY ADVISORS
 # GitHub ID, Name, Email address, Company
+"justincormack","Justin Cormack","justin.cormack@docker.com","Docker"


### PR DESCRIPTION
I don't think Justin needs a lot of introduction as he is known by enough maintainers, so he is a good candidate to be the first security advisor and guinea pig.