### PR TITLE
Add Samuel Karp as security advisor

### DIFF
--- a/SECURITY_ADVISORS
+++ b/SECURITY_ADVISORS
@@ -7,3 +7,4 @@
 "justincormack","Justin Cormack","justin.cormack@docker.com","Docker"
 "rtheis","Richard Theis","rtheis@us.ibm.com","IBM"
 "ralphbuk","Ralph Bateman","ralph@uk.ibm.com","IBM"
+"samuelkarp","Samuel Karp","skarp@amazon.com","Amazon Web Services"


### PR DESCRIPTION
Sam has been well known and active in the containerd community
for some time and has already taken on an advisory role
for many issues.