### PR TITLE
Add Tõnis Tiigi as a security advisor

### DIFF
--- a/SECURITY_ADVISORS
+++ b/SECURITY_ADVISORS
@@ -10,3 +10,4 @@
 "samuelkarp","Samuel Karp","skarp@amazon.com","Amazon Web Services"
 "SergeyKanzhelev","Sergey Kanzhelev","skanzhelev@google.com","Google"
 "tianon","Tianon Gravi","tianon@infosiftr.com","InfoSiftr"
+"tonistiigi","Tõnis Tiigi","tonistiigi@gmail.com","Docker"


### PR DESCRIPTION
Tõnis (@tonistiigi) is the leading maintainer of BuildKit and its relevant projects.

We should collaborate with him for handling vulnerabilities.
