### PR TITLE
Add dims as maintainer

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -17,6 +17,7 @@
 "yujuhong","Yu-Ju Hong","yjhong@google.com"
 "fuweid","Wei Fu","yuge.fw@alibaba-inc.com"
 "mxpv","Maksym Pavlenko","pavlenko.maksym@gmail.com"
+"dims", "Davanum Srinivas","davanum@gmail.com"
 #
 # REVIEWERS
 # GitHub ID, Name, Email address
@@ -30,7 +31,6 @@
 "cpuguy83","Brian Goff","cpuguy83@gmail.com"
 "thajeztah","Sebastiaan van Stijn","github@gone.nl"
 "Zyqsempai","Boris Popovschi","zyqsempai@mail.ru"
-"dims", "Davanum Srinivas","davanum@gmail.com"
 "kzys", "Kazuyoshi Kato", "katokazu@amazon.com"
 "kevpar", "Kevin Parsons", "kevpar@microsoft.com"
 "ktock", "Kohei Tokunaga", "ktokunaga.mail@gmail.com"


### PR DESCRIPTION
Dims has been actively contributing to containerd for months now
and has provided crucial help in stabilizing the CRI plugin through
its transition to the containerd core repo.

---
9 maintainer LGTM required (2/3 of 13 maintainers) + new maintainer

* [x]  @dims (required)
* [x]  @estesp
* [x]  @mxpv
* [x]  @AkihiroSuda
* [x]  @crosbymichael
* [x]  @dmcgowan
* [ ]  @jterry75
* [x]  @mlaventure
* [x]  @stevvooe
* [ ]  @dchen1107
* [ ]  @Random-Liu
* [x]  @mikebrow
* [ ]  @yujuhong
* [x]  @fuweid