### PR TITLE
Explicitly state security announce channel of non-core packages

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -37,13 +37,13 @@ using the same security mailing list as for reporting vulnerabilities.
 
 ## Joining the security announce mailing list
 
-Any organization or individual who directly uses containerd in production or in
-a security critical application is eligible to join the security announce
-mailing list. Indirect users who use containerd through a vendor are not
-expected to join, but should request their vendor join. To join the mailing
-list, the individual or organization must be sponsored by either a containerd
-maintainer or security advisor as well as have a record of properly handling
-non-public security information. If a sponsor cannot be found, sponsorship may
-be requested at `security@containerd.io`. Sponsorship should not be requested
-via public channels since membership of the security announce list is not
-public.
+Any organization or individual who directly uses containerd and non-core
+packages in production or in a security critical application is eligible to join
+the security announce mailing list. Indirect users who use containerd through a
+vendor are not expected to join, but should request their vendor join. To join
+the mailing list, the individual or organization must be sponsored by either a
+containerd maintainer or security advisor as well as have a record of properly
+handling non-public security information. If a sponsor cannot be found,
+sponsorship may be requested at `security@containerd.io`. Sponsorship should not
+be requested via public channels since membership of the security announce list
+is not public.


### PR DESCRIPTION
Related issue: https://github.com/containerd/stargz-snapshotter/issues/436

[SECURITY.md](https://github.com/ktock/project/blob/main/SECURITY.md) points to `security@containerd.io` for reporting vulnerabilities of non-core packages.

>  For any security issues discovered on older versions, non-core packages, or dependencies, please inform maintainers using the same security mailing list as for reporting vulnerabilities.

We should explicitly describe that security announce mailing(`containerd-security-announce@lists.cncf.io`) is used for security announce of non-core packages as well.

cc: @kzys, @estesp, @samuelkarp, @AkihiroSuda
Thank you for the discussion on slack!
