### PR TITLE
Remove Kenfe-Mickael Laventure from maintainers list

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -8,7 +8,6 @@
 "crosbymichael","Michael Crosby","crosbymichael@gmail.com"
 "dmcgowan","Derek McGowan","derek@mcgstyle.net"
 "estesp","Phil Estes","estesp@gmail.com"
-"mlaventure","Kenfe-Mickaël Laventure","mickael.laventure@gmail.com"
 "stevvooe","Stephen Day","stevvooe@gmail.com"
 "dchen1107","Dawn Chen","dawnchen@google.com"
 "Random-Liu","Lantao Liu","lantaol@google.com"


### PR DESCRIPTION
Unfortunately, despite my best effort, I have been unable to go back
into being a productive contributor to containerd and even less so to
fulfill my role as a maintainer. As such, I think it is time for me to
remove myself from the list. I'll still lurk around though :eyes:

Signed-off-by: Kenfe-Mickael Laventure <mickael.laventure@gmail.com>