### PR TITLE
Add Kazuyoshi Kato as committer

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -17,6 +17,7 @@
 "mxpv","Maksym Pavlenko","pavlenko.maksym@gmail.com"
 "dims","Davanum Srinivas","davanum@gmail.com"
 "kevpar","Kevin Parsons","kevpar@microsoft.com"
+"kzys","Kazuyoshi Kato","katokazu@amazon.com"
 #
 # REVIEWERS
 # GitHub ID, Name, Email address
@@ -31,7 +32,6 @@
 "cpuguy83","Brian Goff","cpuguy83@gmail.com"
 "thajeztah","Sebastiaan van Stijn","github@gone.nl"
 "Zyqsempai","Boris Popovschi","zyqsempai@mail.ru"
-"kzys","Kazuyoshi Kato","katokazu@amazon.com"
 "ktock","Kohei Tokunaga","ktokunaga.mail@gmail.com"
 "samuelkarp","Samuel Karp","skarp@amazon.com"
 "dcantah","Daniel Canter","dcanter@microsoft.com"


### PR DESCRIPTION
Kazu has been actively contributing to containerd for awhile now. As contributor, he has taken on solving complex issues and contributing significant features to containerd. He has been one of the most active in the community helping users with their issues and triaging bugs. Quality is very important to containerd and we have adopted a strict review process to maintain it. Kazu has been very helpful in providing frequent and in-depth code reviews to help us maintain the quality of containerd and our associated projects. All this qualifies Kazu to move to the committer role, which is primarily differentiated by the responsibility to maintain the overall quality and direction of the containerd project.

9 committer LGTM required (2/3 of 13 committers) + new committer

* [x] @kzys
* [x]  @estesp
* [x]  @mxpv
* [x]  @akihirosuda
* [ ]  @crosbymichael
* [x]  @dmcgowan
* [x]  @stevvooe
* [ ]  @dchen1107
* [ ]  @Random-Liu
* [x]  @mikebrow
* [ ]  @yujuhong
* [x]  @fuweid
* [x]  @dims
* [x]  @kevpar