### PR TITLE
Add Samuel Karp as committer

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -18,6 +18,7 @@
 "dims","Davanum Srinivas","davanum@gmail.com"
 "kevpar","Kevin Parsons","kevpar@microsoft.com"
 "kzys","Kazuyoshi Kato","katokazu@amazon.com"
+"samuelkarp","Samuel Karp","me@samuelkarp.com"
 #
 # REVIEWERS
 # GitHub ID, Name, Email address
@@ -33,6 +34,5 @@
 "thajeztah","Sebastiaan van Stijn","github@gone.nl"
 "Zyqsempai","Boris Popovschi","zyqsempai@mail.ru"
 "ktock","Kohei Tokunaga","ktokunaga.mail@gmail.com"
-"samuelkarp","Samuel Karp","me@samuelkarp.com"
 "dcantah","Daniel Canter","dcanter@microsoft.com"
 "MikeZappa87","Michael Zappa","Michael.Zappa@Stateless.net"

--- a/SECURITY_ADVISORS
+++ b/SECURITY_ADVISORS
@@ -7,7 +7,6 @@
 "justincormack","Justin Cormack","justin.cormack@docker.com","Docker"
 "rtheis","Richard Theis","rtheis@us.ibm.com","IBM"
 "ralphbuk","Ralph Bateman","ralph@uk.ibm.com","IBM"
-"samuelkarp","Samuel Karp","me@samuelkarp.com","Independent"
 "SergeyKanzhelev","Sergey Kanzhelev","skanzhelev@google.com","Google"
 "tianon","Tianon Gravi","admwiggin@gmail.com","Docker"
 "tonistiigi","Tõnis Tiigi","tonistiigi@gmail.com","Docker"


### PR DESCRIPTION
Sam is a long time contributor and user of containerd. He has helped out in many roles including reviewer, security advisor, as well as helping out with design feedback and getting directly involved in the security release process. He has shown a strong commitment to maintaining the overall project quality and understanding of the project scope.

10 committer LGTM required (2/3 of 14 committers) + new committer

* [x]  @samuelkarp
* [x]  @estesp
* [x]  @mxpv
* [x]  @akihirosuda
* [x]  @crosbymichael
* [x]  @dmcgowan
* [ ]  @stevvooe
* [ ]  @dchen1107
* [ ]  @Random-Liu
* [x]  @mikebrow
* [ ]  @yujuhong
* [x]  @fuweid
* [x]  @dims
* [x]  @kevpar
* [x]  @kzys