### PR TITLE
Enable OpenSSF Scorecard Github Action

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -1,0 +1,54 @@
+name: Scorecards supply-chain security
+on:
+  # Only the default branch is supported.
+  branch_protection_rule:
+  schedule:
+    - cron: '23 14 * * 1'
+  push:
+    branches: [ "main" ]
+
+# Declare default permissions as read only.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecards analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed to upload the results to code-scanning dashboard.
+      security-events: write
+      # Used to receive a badge.
+      id-token: write
+
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 # tag=v3.0.0
+        with:
+          persist-credentials: false
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@865b4092859256271290c77adbd10a43f4779972 # tag=v2.0.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+
+          # Publish the results for public repositories to enable scorecard badges. For more details, see
+          # https://github.com/ossf/scorecard-action#publishing-results.
+          # For private repositories, `publish_results` will automatically be set to `false`, regardless
+          # of the value entered here.
+          publish_results: true
+
+      # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
+      # format to the repository Actions tab.
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@6673cd052c4cd6fcf4b4e6e60ea986c889389535 # tag=v3.0.0
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      # Upload the results to GitHub's code scanning dashboard.
+      - name: "Upload to code-scanning"
+        uses: github/codeql-action/upload-sarif@5f532563584d71fdef14ee64d17bafb34f751ce5 # tag=v1.0.26
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # containerd common project repository
+
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/containerd/project/badge)](https://api.securityscorecards.dev/projects/github.com/containerd/project)
+
 This cross-project repository holds utilities, scripts, and common files
 used across the containerd core projects and many sub-projects within
 the containerd organization.


### PR DESCRIPTION
Closes #91 

Hi, as mentioned in #91, here is the changes that enable the OpenSSF Scorecard Github Action and add the Badge to the README file (which is completely optional).

Thanks for the attention to the issue and any concerns please reach me out.

