### PR TITLE
Update GitHub actions packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
 
     - name: Set up Go 1.19
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v3
       with:
         go-version: 1.19
       id: go
@@ -27,7 +27,7 @@ jobs:
         echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
 
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: src/github.com/containerd/project
         fetch-depth: 25


### PR DESCRIPTION
Update actions/checkout and actions/setup-go from v2 to v3.

https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

Related issue: https://github.com/containerd/project/issues/95

Signed-off-by: Austin Vazquez <macedonv@amazon.com>