### PR TITLE
Add an emeritus role to governance

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -178,28 +178,61 @@ At the very least, ensure your work can be continued where you left off.
 After you've informed other maintainers, create a pull request to remove
 yourself from the MAINTAINERS file.
 
-## Removal of inactive maintainers
+## Handling inactive maintainers
 
 Similar to the procedure for adding new maintainers, existing maintainers can
-be removed from the list if they do not show significant activity on the
-project. Periodically, the maintainers review the list of maintainers and their
-activity over the last year.
+be removed from the list if they do not show consistent activity on the
+project. Depending on the existing role, committer or reviewer, there are
+variations to the inactivity process detailed as follows.
 
-If a maintainer has shown insufficient activity over this period, a neutral
-person will contact the maintainer to ask if they want to continue being
-a maintainer. If the maintainer decides to step down as a maintainer, they
-open a pull request to be removed from the MAINTAINERS file.
+### Committer inactivity process
 
-If a committer is unable to continue participating in project level votes but
-wishes to remain a maintainer on the project, they may convert their role to
-a reviewer until they are able to perform committer duties again.
+For committers, the maintainers periodically review committer project
+activity. The maintainers use the CNCF "devstats" community metrics tool for
+data on user activity statistics.
 
-If an inactive maintainer wants to remain in their current role or does not open
-their own pull request to change roles, another maintainer may open up a pull
-request to the MAINTAINERS file to change their role. Role changes and removals
-must be approved by 2/3 of the current committers. The voting and discussion
-period is seven days, after which a committer will verify the votes,
-merge the pull request, and apply the changes to the organization.
+If a committer has shown no activity over a six-month period, the committer
+will be contacted to notify them of their activity status and offer a move to
+an Emeritus role. There is no automatic change of status in the project. First,
+the activity status is discussed directly with the committer, and second,
+maintainers discuss whether other non-tracked contributions to the project
+reflect an ongoing, active participation in the project.
+
+Based on the outcome of these discussions, the committer may choose to remove
+themselves from the MAINTAINERS file, as noted above in the "Stepping down
+policy" section. If another maintainer opens a pull request to the MAINTAINERS
+file on their behalf for removal, the PR must be approved by 2/3 of the current
+committers, or by the committer who is being removed. The voting and discussion
+period is seven days, after which a committer will verify the votes, merge the
+pull request, and apply the changes to the organization.
+
+### Reviewer inactivity process
+
+While reviewers are not voting members of the containerd project, the maintainers
+may assess reviewer activity periodically and recommend removals for any
+completely inactive reviewers.
+
+Reviewers may remove themselves from the MAINTAINERS file if they wish to or
+any existing maintainer may open a pull request to the MAINTAINERS file on their
+behalf. If the pull request is not initiated by the reviewer, it must be approved
+by 2/3 of the current committers or by the reviewer who is being removed. The
+voting and discussion period is seven days, after which a committer will verify
+the votes, merge the pull request, and apply the changes to the organization.
+
+## Emeritus maintainers
+
+For committers who are stepping down or being removed due to inactivity,
+the project would like to memorialize their contributions to the project by
+recognizing them as Emeritus maintainers in the EMERITUS.md file. The EMERITUS.md
+file will include a brief paragraph summarizing their contribution to the
+containerd project and recognize them as permanent Emeritus members of the
+community.
+
+If in the future an Emeritus maintainer has the desire or ability to return to
+contributing to the project, Emeritus maintainers can submit a pull request
+reversing their removal from the MAINTAINERS file and approval only requires
+2 LGTMs from current committers to return to full committer status in the
+project.
 
 ## How are decisions made?
 


### PR DESCRIPTION
Containerd as a project is nearing seven years since it’s creation inside Docker as a process supervisor on top of the initial OCI runc. Early next year it will have spent six of those years as a CNCF project with our current governance and scope as a “stable, core container runtime.”

In that span of time many people have contributed to containerd, and alongside a large and growing list of contributors, the core group of maintainers–both committers, and a reviewer role added over time–has grown from a small handful of initial maintainers into a [fairly long list](https://github.com/containerd/project/blob/455e669cfc6d7b6a4c6e17fec49659ad001419be/MAINTAINERS); 15 committers and 15 reviewers to be exact.

It is also understandable that over such a long time period many early contributors, including maintainers, have taken on new roles which have changed their main focus and/or direction potentially away from the project, or even this area of technology. Sometimes those changes keep them from having time or ability to regularly participate in the project. Over a span of years this can introduce an ebb and flow of activity from specific contributors, but can also lead to situations where, at least for the known future, some participants will end up with no ongoing activity in the project.

To help with project velocity and specifically make it less painful to reach quorum on issues which require committer voting, we are proposing a new emeritus status for committers as an addition to our current project governance. We are not the first open source project to have this mechanism, and it allows for us to recognize the extremely valuable contributions of various long-time committers without them simply disappearing from the project MAINTAINERS file.

This patch to the GOVERNANCE.md explains this new role and clarifies how maintainers will use data to determine who is to be proposed for the emeritus role. It is important to recognize, however, that this is not a decision that will be made by a "tool" based only on commit data. The commit data will be the starting point for a conversation which may lead to maintainers determining that someone is still key to the overall project in non-tracked contributions and is available for votes, as one example.

- Patch commit details:
```
Adds an emeritus role to containerd project governance for committers stepping down from the project.
Clarifies expectations of activity and a more specific process for review.
Distinguishes reviewer from committer stepping down processes.

Signed-off-by: Phil Estes <estesp@amazon.com>
```

### Governance change requires 2/3s vote of existing committers

10 committer LGTM required (2/3 of 15 committers)

* [x]   @samuelkarp 
* [x]   @kzys
* [x]   @estesp
* [x]   @mxpv
* [x]   @AkihiroSuda
* [ ]   @crosbymichael
* [x]   @dmcgowan
* [ ]   @stevvooe
* [ ]   @dchen1107
* [ ]   @Random-Liu
* [x]   @mikebrow
* [ ]   @yujuhong
* [x]   @fuweid
* [x]   @dims
* [x]   @kevpar