### PR TITLE
Remove inactive reviewers

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -23,16 +23,8 @@
 # REVIEWERS
 # GitHub ID, Name, Email address, GPG fingerprint
 "jterry75","Justin Terry","jlterry@amazon.com",""
-"abhi","Abhinandan Prativadi","aprativadi@gmail.com",""
-"dqminh","Daniel, Dao Quang Minh","dqminh89@gmail.com",""
-"hqhq","Qiang Huang","h.huangqiang@huawei.com",""
-"yanxuean","Xuean Yan","yan.xuean@zte.com.cn",""
-"miaoyq","Yanqiang Miao","miao.yanqiang@zte.com.cn",""
-"ehazlett","Evan Hazlett","ejhazlett@gmail.com",""
-"Ace-Tang","Ace Tang","huamin.thm@alibaba-inc.com",""
 "cpuguy83","Brian Goff","cpuguy83@gmail.com",""
 "thajeztah","Sebastiaan van Stijn","github@gone.nl","DE9A E9A2 F211 75DC B4F0 E564 7669 8F39 D527 CE8C"
-"Zyqsempai","Boris Popovschi","zyqsempai@mail.ru",""
 "ktock","Kohei Tokunaga","ktokunaga.mail@gmail.com",""
 "dcantah","Daniel Canter","danny@dcantah.dev",""
 "MikeZappa87","Michael Zappa","Michael.Zappa@gmail.com",""


### PR DESCRIPTION
Removes reviewers who according to devstats have not been active in the containerd org in the last year.

This is part of an effort to encourage more contributors to get involved and become reviewers. Our reviewer list gives a false impression that we have more individuals reviewing code than we actually do.

Thank you to these contributors for the all they have done for the project over the years. As always, you are welcome back to the project anytime!

Dev stats links used (_this user data only goes back to June 2022, so you'll see an error message if no contributions since then_):
[abhi](https://containerd.devstats.cncf.io/d/48/users-statistics-by-repository-group?orgId=1&from=now-1y&to=now&var-period=d7&var-metric=activity&var-repogroup_name=All&var-users=abhi)
[dqminh](https://containerd.devstats.cncf.io/d/48/users-statistics-by-repository-group?orgId=1&from=now-1y&to=now&var-period=d7&var-metric=activity&var-repogroup_name=All&var-users=dqminh)
[hqhq](https://containerd.devstats.cncf.io/d/48/users-statistics-by-repository-group?orgId=1&from=now-1y&to=now&var-period=d7&var-metric=activity&var-repogroup_name=All&var-users=hqhq)
[yanxuean](https://containerd.devstats.cncf.io/d/48/users-statistics-by-repository-group?orgId=1&from=now-1y&to=now&var-period=d7&var-metric=activity&var-repogroup_name=All&var-users=yanxuean)
[miaoyq](https://containerd.devstats.cncf.io/d/48/users-statistics-by-repository-group?orgId=1&from=now-1y&to=now&var-period=d7&var-metric=activity&var-repogroup_name=All&var-users=miaoyq)
[ehazlett](https://containerd.devstats.cncf.io/d/48/users-statistics-by-repository-group?orgId=1&from=now-1y&to=now&var-period=d7&var-metric=activity&var-repogroup_name=All&var-users=ehazlett)
[Ace-Tang](https://containerd.devstats.cncf.io/d/48/users-statistics-by-repository-group?orgId=1&from=now-1y&to=now&var-period=d7&var-metric=activity&var-repogroup_name=All&var-users=Ace-Tang)
[Zyqsempai](https://containerd.devstats.cncf.io/d/48/users-statistics-by-repository-group?orgId=1&from=now-1y&to=now&var-period=d7&var-metric=activity&var-repogroup_name=All&var-users=Zyqsempai)

10 committer LGTM required (2/3 of 15 committers)

* [x] @AkihiroSuda 
* [ ] @crosbymichael 
* [x] @dmcgowan 
* [x] @estesp 
* [ ] @stevvooe 
* [ ] @dchen1107 
* [ ] @Random-Liu 
* [x] @mikebrow 
* [ ] @yujuhong 
* [x] @fuweid 
* [x] @mxpv 
* [x] @dims 
* [x] @kevpar 
* [x] @kzys 
* [x] @samuelkarp 