### PR TITLE
Recognize Lantao Liu as an emeritus maintainer

### DIFF
--- a/EMERITUS.md
+++ b/EMERITUS.md
@@ -16,3 +16,14 @@ runtime codebase from the API to the OCI runtime.
 
 A significant contributor to the CRI plugin and container networking, Abhi helped make
 containerd a reliable and complete container runtime for Kubernetes.
+
+## Lantao Liu [@Random-Liu](https://github.com/Random-Liu)
+
+Lantao Liu was one of the initial authors of the containerd CRI plugin.  Lantao
+worked across the Kubelet, Kubernetes project infrastructure, CRI, and
+containerd to enable containerd to be one of the first CRI-enabled runtimes for
+Kubernetes.  containerd is now the default container runtime for several
+Kubernetes providers, which would not have been possible without Lantao's
+dedicated work.  While Lantao is no longer involved in the day-to-day
+maintenance of the CRI plugin or containerd in general, he remains involved in
+the larger Kubernetes community.

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -10,7 +10,6 @@
 "estesp","Phil Estes","estesp@gmail.com","71AE 6DCD DFF8 C2D1 DDCA EEC9 FE25 9812 6B19 6A38"
 "stevvooe","Stephen Day","stevvooe@gmail.com",""
 "dchen1107","Dawn Chen","dawnchen@google.com",""
-"Random-Liu","Lantao Liu","lantaol@google.com",""
 "mikebrow","Mike Brown","brownwm@us.ibm.com",""
 "yujuhong","Yu-Ju Hong","yjhong@google.com",""
 "fuweid","Fu Wei","fuweid89@gmail.com",""


### PR DESCRIPTION
Let's recognize @Random-Liu as an emeritus committer.

Lantao Liu was one of the initial authors of the containerd CRI plugin.  Lantao worked across the Kubelet, Kubernetes project infrastructure, CRI, and containerd to enable containerd to be one of the first CRI-enabled runtimes for Kubernetes.  containerd is now the default container runtime for several Kubernetes providers, which would not have been possible without Lantao's dedicated work.  While Lantao is no longer involved in the day-to-day maintenance of the CRI plugin or containerd in general, he remains involved in the larger Kubernetes community.

Conversion to emeritus status requires either:
1. approval of the committer in question, or
   - [x] @Random-Liu 
2. 2/3 of the current committers (10 votes)
   - [x] @AkihiroSuda
   - [ ] @crosbymichael
   - [x] @dmcgowan
   - [x] @estesp
   - [ ] @stevvooe
   - [x] @dchen1107
   - [ ] @Random-Liu
   - [x] @mikebrow
   - [ ] @yujuhong
   - [ ] @fuweid
   - [x] @mxpv
   - [x] @dims
   - [ ] @kevpar
   - [ ] @kzys
   - [x] @samuelkarp

The voting and discussion period is seven days, after which a committer will verify the votes, merge the pull request, and apply the changes to the organization.