### PR TITLE
Recognize Dawn Chen as an emeritus maintainer

### DIFF
--- a/EMERITUS.md
+++ b/EMERITUS.md
@@ -27,3 +27,14 @@ Kubernetes providers, which would not have been possible without Lantao's
 dedicated work.  While Lantao is no longer involved in the day-to-day
 maintenance of the CRI plugin or containerd in general, he remains involved in
 the larger Kubernetes community.
+
+## Dawn Chen [@dchen1107](https://github.com/dchen1107)
+
+Dawn Chen was the initiator of CRI for Kubernetes, and an important partner in
+enabling the containerd CRI plugin to happen.  Dawn coordinated the needs of
+Kubernetes SIG-Node with containerd.  containerd is now well-supported and a
+critical part of Kubernetes validation, which would not have been possible
+without Dawn’s advocacy.  While Dawn is no longer involved in the day-to-day
+maintenance of the CRI plugin or containerd in general, she continues to serve
+as a Technical Lead for SIG-Node and an advocate for containerd in the
+Kubernetes community.

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -9,7 +9,6 @@
 "dmcgowan","Derek McGowan","derek@mcgstyle.net","8C7A 111C 2110 5794 B0E8 A27B F58C 5D0A 4405 ACDB"
 "estesp","Phil Estes","estesp@gmail.com","71AE 6DCD DFF8 C2D1 DDCA EEC9 FE25 9812 6B19 6A38"
 "stevvooe","Stephen Day","stevvooe@gmail.com",""
-"dchen1107","Dawn Chen","dawnchen@google.com",""
 "mikebrow","Mike Brown","brownwm@us.ibm.com",""
 "yujuhong","Yu-Ju Hong","yjhong@google.com",""
 "fuweid","Fu Wei","fuweid89@gmail.com",""


### PR DESCRIPTION
Thank you @dchen1107 for all your work here!

Dawn Chen was the initiator of CRI for Kubernetes, and an important partner in enabling the containerd CRI plugin to happen.  Dawn coordinated the needs of Kubernetes SIG-Node with containerd.  containerd is now well-supported and a critical part of Kubernetes validation, which would not have been possible without Dawn’s advocacy.  While Dawn is no longer involved in the day-to-day maintenance of the CRI plugin or containerd in general, she continues to serve as a Technical Lead for SIG-Node and an advocate for containerd in the Kubernetes community.

Conversion to emeritus status requires either:
1. approval of the committer in question, or
   - [x] @dchen1107
2. 2/3 of the current committers (10 votes)
   - [ ] @AkihiroSuda
   - [ ] @crosbymichael
   - [x] @dmcgowan
   - [ ] @estesp
   - [ ] @stevvooe
   - [x] @dchen1107
   - [ ] @mikebrow
   - [ ] @yujuhong
   - [ ] @fuweid
   - [ ] @mxpv
   - [x] @dims
   - [ ] @kevpar
   - [x] @kzys
   - [x] @samuelkarp

The voting and discussion period is seven days, after which a committer will verify the votes, merge the pull request, and apply the changes to the organization.