### PR TITLE
Recognize Yu-Ju Hong as an emeritus maintainer

### DIFF
--- a/EMERITUS.md
+++ b/EMERITUS.md
@@ -38,3 +38,12 @@ without Dawn’s advocacy.  While Dawn is no longer involved in the day-to-day
 maintenance of the CRI plugin or containerd in general, she continues to serve
 as a Technical Lead for SIG-Node and an advocate for containerd in the
 Kubernetes community.
+
+## Yu-Ju Hong [@yujuhong](https://github.com/yujuhong)
+
+Yu-Ju Hong proposed the first version of CRI and was a key part of early
+implementation of the containerd CRI plugin.  Her work enabled Kubernetes to
+invoke runtimes via CRI, allowed the Kubernetes CI environment to test CRI
+integrations like containerd, and provided a standard set of tools and test
+suite for container runtimes.  While Yu-Ju is not currently involved in
+containerd, she remains involved in the larger Kubernetes community.

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -10,7 +10,6 @@
 "estesp","Phil Estes","estesp@gmail.com","71AE 6DCD DFF8 C2D1 DDCA EEC9 FE25 9812 6B19 6A38"
 "stevvooe","Stephen Day","stevvooe@gmail.com",""
 "mikebrow","Mike Brown","brownwm@us.ibm.com",""
-"yujuhong","Yu-Ju Hong","yjhong@google.com",""
 "fuweid","Fu Wei","fuweid89@gmail.com",""
 "mxpv","Maksym Pavlenko","pavlenko.maksym@gmail.com",""
 "dims","Davanum Srinivas","davanum@gmail.com","A67E 5FD8 80EB 089F 2317 7967 80D8 3A79 6103 BF59"


### PR DESCRIPTION
Thank you @yujuhong!

Yu-Ju Hong proposed the first version of CRI and was a key part of early implementation of the containerd CRI plugin.  Her work enabled Kubernetes to invoke runtimes via CRI, allowed the Kubernetes CI environment to test CRI integrations like containerd, and provided a standard set of tools and test suite for container runtimes.  While Yu-Ju is not currently involved in containerd, she remains involved in the larger Kubernetes community.

Conversion to emeritus status requires either:
1. approval of the committer in question, or
   - [ ] @yujuhong
2. 2/3 of the current committers (9 votes)
   - [x] @AkihiroSuda
   - [ ] @crosbymichael
   - [x] @dmcgowan
   - [x] @estesp
   - [ ] @stevvooe
   - [x] @mikebrow
   - [ ] @yujuhong
   - [x] @fuweid
   - [x] @mxpv
   - [x] @dims
   - [ ] @kevpar
   - [x] @kzys
   - [x] @samuelkarp

The voting and discussion period is seven days, after which a committer will verify the votes, merge the pull request, and apply the changes to the organization.