### PR TITLE
Add Stephen Day as Emeritus maintainer

### DIFF
--- a/EMERITUS.md
+++ b/EMERITUS.md
@@ -47,3 +47,12 @@ invoke runtimes via CRI, allowed the Kubernetes CI environment to test CRI
 integrations like containerd, and provided a standard set of tools and test
 suite for container runtimes.  While Yu-Ju is not currently involved in
 containerd, she remains involved in the larger Kubernetes community.
+
+## Stephen Day [@stevvooe](https://github.com/stevvooe)
+
+Both the author of the initial distribution specification and architect behind
+many of the containerd 1.0 designs, Stephen Day has had a tremendous impact on
+the container ecosystem. The containerd project has greatly benefited from
+Stephen’s bold and innovative ideas along with his large impact on the
+containerd codebase. We can both thank and `git blame` Stephen for many parts of
+containerd.

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -8,7 +8,6 @@
 "crosbymichael","Michael Crosby","crosbymichael@gmail.com",""
 "dmcgowan","Derek McGowan","derek@mcgstyle.net","8C7A 111C 2110 5794 B0E8 A27B F58C 5D0A 4405 ACDB"
 "estesp","Phil Estes","estesp@gmail.com","71AE 6DCD DFF8 C2D1 DDCA EEC9 FE25 9812 6B19 6A38"
-"stevvooe","Stephen Day","stevvooe@gmail.com",""
 "mikebrow","Mike Brown","brownwm@us.ibm.com",""
 "fuweid","Fu Wei","fuweid89@gmail.com",""
 "mxpv","Maksym Pavlenko","pavlenko.maksym@gmail.com",""


### PR DESCRIPTION
Thanks @stevvooe, I'm optimistic you'll be back though!

> Both the author of the initial distribution specification and architect behind
> many of the containerd 1.0 designs, Stephen Day has had a tremendous impact on
> the container ecosystem. The containerd project has greatly benefited from
> Stephen’s bold and innovative ideas along with his large impact on the
> containerd codebase. We can both thank and `git blame` Stephen for many parts of
> containerd.

Conversion to emeritus status requires either:
1. approval of the committer in question, or
   - [x] @stevvooe 
2. 2/3 of the current committers (8 votes)
   - [x] @AkihiroSuda
   - [ ] @crosbymichael
   - [x] @dmcgowan
   - [x] @estesp
   - [x] @stevvooe
   - [x] @mikebrow
   - [x] @fuweid
   - [x] @mxpv
   - [x] @dims
   - [ ] @kevpar
   - [x] @kzys
   - [x] @samuelkarp

The voting and discussion period is seven days, after which a committer will verify the votes, merge the pull request, and apply the changes to the organization.