### PR TITLE
Add Aditi and Akhil as security advisors

### DIFF
--- a/SECURITY_ADVISORS
+++ b/SECURITY_ADVISORS
@@ -12,3 +12,5 @@
 "tonistiigi","Tõnis Tiigi","tonistiigi@gmail.com","Docker"
 "cji","Craig Ingram","cjingram@google.com","Google"
 "henry118","Henry Wang","henwang@amazon.com","AWS"
+"adisky","Aditi Sharma","adi.sky17@gmail.com","VMware"
+"akhilerm","Akhil Mohan","akhilerm@gmail.com","VMware"


### PR DESCRIPTION
I propose adding Aditi and Akhil as security advisors representing VMware. Both are well-known and active contributors to the project.