### PR TITLE
Update governance to add wording for core subprojects having a maintainers list

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -137,6 +137,12 @@ core committers.
 If a project is approved, a maintainer will add the project to the containerd
 GitHub organization, and make an announcement on a public forum.
 
+Core projects may have a separate maintainers list which are responsible for
+only maintaining their subproject. The `MAINTAINERS` file of a core subproject
+will only need to list the additional maintainers for that subproject-the core
+maintainers will also be responsible for maintenance but do not need to be
+appended to each subproject.
+
 Please add the suggested text from our [Project core documents](./README.md#project-core-documents) section
 to your `README.md`.
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ As a containerd sub-project, you will find the:
 information in our [`containerd/project`](https://github.com/containerd/project) repository.
 ```
 
+If the project has its own `MAINTAINERS` file, that file should contain a comment with a link to
+the core `MAINTAINERS` file in `containerd/project` and mention it as additional maintainers.
+
 ### Non-core project documents
 
 If your project is a non-core addition to the containerd GitHub organization, please


### PR DESCRIPTION
In order to help core projects grow and be better maintained, they can have their own maintainers list, similar to non-core projects. This allows the projects to have more autonomy and grow the overall project without having core committers heavily involved in every repository.

7 committer LGTM required (2/3 of 10 committers)

- [ ] @AkihiroSuda
- [x] @dmcgowan
- [ ] @estesp
- [x] @mikebrow
- [x] @fuweid
- [x] @mxpv
- [x] @dims
- [x] @kzys
- [x] @samuelkarp
- [x] @kiashok